### PR TITLE
Feature/use consumer api

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
     "url": "https://github.com/process-engine/management_api_contracts/issues"
   },
   "homepage": "https://github.com/process-engine/management_api_contracts#readme",
+  "dependencies": {
+    "@process-engine/consumer_api_contracts": "^0.14.0"
+  },
   "devDependencies": {
     "@essential-projects/tslint-config": "1.0.0",
     "@types/express": "^4.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/management_api_contracts",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "interfaces for the process-engine.io Management APIs",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",

--- a/src/data_models/event/event.ts
+++ b/src/data_models/event/event.ts
@@ -1,6 +1,5 @@
-export class Event {
-  public key: string;
-  public id?: string;
-  public processInstanceId?: string;
-  public data?: any; // TODO: Define event-payload
+import {Event as ConsumerApiEvent} from '@process-engine/consumer_api_contracts';
+
+export class Event extends ConsumerApiEvent {
+
 }

--- a/src/data_models/event/event_list.ts
+++ b/src/data_models/event/event_list.ts
@@ -1,5 +1,7 @@
-import {Event} from './event';
+import {EventList as ConsumerApiEventList} from '@process-engine/consumer_api_contracts';
 
-export interface EventList {
+import {Event} from '../index';
+
+export interface EventList extends ConsumerApiEventList {
   events: Array<Event>;
 }

--- a/src/data_models/process_model_execution/process_model.ts
+++ b/src/data_models/process_model_execution/process_model.ts
@@ -1,7 +1,8 @@
+import {ProcessModel as ConsumerApiProcessModel} from '@process-engine/consumer_api_contracts';
+
 import {Event} from '../index';
 
-export class ProcessModel {
-  public key: string;
+export class ProcessModel extends ConsumerApiProcessModel {
   public xml: string;
   public startEvents: Array<Event> = [];
   public endEvents: Array<Event> = [];

--- a/src/data_models/process_model_execution/process_model_list.ts
+++ b/src/data_models/process_model_execution/process_model_list.ts
@@ -1,5 +1,7 @@
-import {ProcessModel} from './index';
+import {ProcessModelList as ConsumerApiProcessModelList} from '@process-engine/consumer_api_contracts';
 
-export class ProcessModelList {
+import {ProcessModel} from '../index';
+
+export class ProcessModelList extends ConsumerApiProcessModelList {
   public processModels: Array<ProcessModel> = [];
 }

--- a/src/data_models/process_model_execution/process_start_request_payload.ts
+++ b/src/data_models/process_model_execution/process_start_request_payload.ts
@@ -1,6 +1,4 @@
-export class ProcessStartRequestPayload {
-  public correlationId?: string;
-   // Note: The CallerId contains a process instance ID and must only ever be set, when a subprocess is to be started.
-  public callerId?: string;
-  public inputValues: any;
+import {ProcessStartRequestPayload as ConsumerApiProcessStartRequestPayload} from '@process-engine/consumer_api_contracts';
+
+export class ProcessStartRequestPayload extends ConsumerApiProcessStartRequestPayload {
 }

--- a/src/data_models/process_model_execution/process_start_response_payload.ts
+++ b/src/data_models/process_model_execution/process_start_response_payload.ts
@@ -1,5 +1,4 @@
-export class ProcessStartResponsePayload {
-  public correlationId: string;
-  public endEventId?: string;
-  public tokenPayload?: string;
+import {ProcessStartResponsePayload as ConsumerApiProcessStartResponsePayload} from '@process-engine/consumer_api_contracts';
+
+export class ProcessStartResponsePayload extends ConsumerApiProcessStartResponsePayload {
 }

--- a/src/data_models/process_model_execution/start_callback_type.ts
+++ b/src/data_models/process_model_execution/start_callback_type.ts
@@ -1,5 +1,3 @@
-export enum StartCallbackType {
-    CallbackOnProcessInstanceCreated = 1,
-    CallbackOnProcessInstanceFinished = 2,
-    CallbackOnEndEventReached = 3,
-}
+import {StartCallbackType as ConsumerApiStartCallbackType} from '@process-engine/consumer_api_contracts';
+
+export type StartCallbackType = ConsumerApiStartCallbackType;

--- a/src/data_models/process_model_execution/start_callback_type.ts
+++ b/src/data_models/process_model_execution/start_callback_type.ts
@@ -1,3 +1,3 @@
 import {StartCallbackType as ConsumerApiStartCallbackType} from '@process-engine/consumer_api_contracts';
 
-export type StartCallbackType = ConsumerApiStartCallbackType;
+export import StartCallbackType = ConsumerApiStartCallbackType;

--- a/src/data_models/user_task/user_task.ts
+++ b/src/data_models/user_task/user_task.ts
@@ -1,9 +1,7 @@
+import {UserTask as ConsumerApiUserTask} from '@process-engine/consumer_api_contracts';
+
 import {UserTaskConfig} from './user_task_config';
 
-export class UserTask {
-  public key: string;
-  public id: string;
-  public processInstanceId: string;
+export class UserTask extends ConsumerApiUserTask {
   public data: UserTaskConfig;
-  public tokenPayload: any; // token payload the UserTask got suspended with
 }

--- a/src/data_models/user_task/user_task_config.ts
+++ b/src/data_models/user_task/user_task_config.ts
@@ -1,5 +1,7 @@
+import {UserTaskConfig as ConsumerApiUserTaskConfig} from '@process-engine/consumer_api_contracts';
+
 import {UserTaskFormField} from './user_task_form_field';
 
-export class UserTaskConfig {
+export class UserTaskConfig extends ConsumerApiUserTaskConfig {
   public formFields: Array<UserTaskFormField> = [];
 }

--- a/src/data_models/user_task/user_task_form_field.ts
+++ b/src/data_models/user_task/user_task_form_field.ts
@@ -1,9 +1,7 @@
+import {UserTaskFormField as ConsumerApiUserTaskFormField} from '@process-engine/consumer_api_contracts';
+
 import {UserTaskFormFieldType} from './user_task_form_field_type';
 
-export class UserTaskFormField {
-  public id: string;
+export class UserTaskFormField extends ConsumerApiUserTaskFormField {
   public type: UserTaskFormFieldType;
-  public label: string;
-  public defaultValue?: any;
-  public preferredControl?: string;
 }

--- a/src/data_models/user_task/user_task_form_field_type.ts
+++ b/src/data_models/user_task/user_task_form_field_type.ts
@@ -1,3 +1,3 @@
 import {UserTaskFormFieldType as ConsumerApiUserTaskFormFieldType} from '@process-engine/consumer_api_contracts';
 
-export type UserTaskFormFieldType = ConsumerApiUserTaskFormFieldType;
+export import UserTaskFormFieldType = ConsumerApiUserTaskFormFieldType;

--- a/src/data_models/user_task/user_task_form_field_type.ts
+++ b/src/data_models/user_task/user_task_form_field_type.ts
@@ -1,8 +1,3 @@
-export enum UserTaskFormFieldType {
-  boolean = 'boolean',
-  date = 'date',
-  enumeration = 'enum',
-  long = 'long',
-  number = 'number',
-  string = 'string',
-}
+import {UserTaskFormFieldType as ConsumerApiUserTaskFormFieldType} from '@process-engine/consumer_api_contracts';
+
+export type UserTaskFormFieldType = ConsumerApiUserTaskFormFieldType;

--- a/src/data_models/user_task/user_task_list.ts
+++ b/src/data_models/user_task/user_task_list.ts
@@ -1,5 +1,7 @@
+import {UserTaskList as ConsumerApiUserTaskList} from '@process-engine/consumer_api_contracts';
+
 import {UserTask} from './user_task';
 
-export class UserTaskList {
+export class UserTaskList extends ConsumerApiUserTaskList {
   public userTasks: Array<UserTask> = [];
 }

--- a/src/data_models/user_task/user_task_result.ts
+++ b/src/data_models/user_task/user_task_result.ts
@@ -1,5 +1,5 @@
-export class UserTaskResult {
-  public formFields: {
-    [fieldId: string]: any,
-  };
+import {UserTaskResult as ConsumerApiUserTaskResult} from '@process-engine/consumer_api_contracts';
+
+export class UserTaskResult extends ConsumerApiUserTaskResult {
+
 }


### PR DESCRIPTION
Closes #11 

## What did you change?

Refactor all the data model contracts, so that they derive their values from their consumer api counterparts. 

Only properties which are specific to the management api remain; like the `xml` property for process models.

## How can others test the changes?

Implement the contracts.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.)
- [x] I've merged the `develop` branch into my branch before finishing this PR.
- [x] I've **not added any other changes** than the ones described above.
- [x] I've mentioned all **PRs, which relate to this one**
