### PR TITLE
♻️ Refactor socket io handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/process-engine/management_api_contracts#readme",
   "dependencies": {
-    "@essential-projects/iam_contracts": "feature~refactor_socket_io_handling"
+    "@essential-projects/iam_contracts": "~3.4.0"
   },
   "devDependencies": {
     "@essential-projects/tslint-config": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "homepage": "https://github.com/process-engine/management_api_contracts#readme",
   "dependencies": {
+    "@essential-projects/event_aggregator_contracts": "~4.0.0",
     "@essential-projects/iam_contracts": "~3.4.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/process-engine/management_api_contracts#readme",
   "dependencies": {
-    "@essential-projects/iam_contracts": "~3.3.0"
+    "@essential-projects/iam_contracts": "feature~refactor_socket_io_handling"
   },
   "devDependencies": {
     "@essential-projects/tslint-config": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/management_api_contracts",
-  "version": "3.0.1",
+  "version": "4.0.0",
   "description": "interfaces for the process-engine.io Management APIs",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",

--- a/src/apis/imanual_task_management_api.ts
+++ b/src/apis/imanual_task_management_api.ts
@@ -106,4 +106,44 @@ export interface IManualTaskManagementApi {
    * @returns          The Subscription created by the EventAggregator.
    */
   onManualTaskFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskFinishedCallback): Promise<Subscription>;
+
+  /**
+   * Executes a callback when a ManualTask for the given identity is reached.
+   *
+   * @async
+   * @param identity        The requesting users identity.
+   * @param callback        The callback that will be executed when a ManualTask
+   *                        is reached.
+   *                        The message passed to the callback contains further
+   *                        information about the ManualTask.
+   * @param   subscribeOnce Optional: If set to true, the Subscription will be
+   *                        automatically disposed, after the notification was
+   *                        received once.
+   * @returns               The Subscription created by the EventAggregator.
+   */
+  onManualTaskForIdentityWaiting(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnManualTaskWaitingCallback,
+    subscribeOnce?: boolean,
+  ): Promise<Subscription>;
+
+  /**
+   * Executes a callback when a ManualTask for the given identity is finished.
+   *
+   * @async
+   * @param   identity      The requesting users identity.
+   * @param   callback      The callback that will be executed when a ManualTask
+   *                        is finished.
+   *                        The message passed to the callback contains further
+   *                        information about the ManualTask.
+   * @param   subscribeOnce Optional: If set to true, the Subscription will be
+   *                        automatically disposed, after the notification was
+   *                        received once.
+   * @returns               The Subscription created by the EventAggregator.
+   */
+  onManualTaskForIdentityFinished(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnManualTaskFinishedCallback,
+    subscribeOnce?: boolean,
+  ): Promise<Subscription>;
 }

--- a/src/apis/imanual_task_management_api.ts
+++ b/src/apis/imanual_task_management_api.ts
@@ -85,27 +85,41 @@ export interface IManualTaskManagementApi {
    * Executes a callback when a ManualTask is reached.
    *
    * @async
-   * @param   identity The requesting users identity.
-   * @param   callback The callback that will be executed when a ManualTask is
-   *                   reached.
-   *                   The message passed to the callback contains further
-   *                   information about the ManualTask.
-   * @returns          The Subscription created by the EventAggregator.
+   * @param   identity      The requesting users identity.
+   * @param   callback      The callback that will be executed when a ManualTask
+   *                        is reached.
+   *                        The message passed to the callback contains further
+   *                        information about the ManualTask.
+   * @param   subscribeOnce Optional: If set to true, the Subscription will be
+   *                        automatically disposed, after the notification was
+   *                        received once.
+   * @returns               The Subscription created by the EventAggregator.
    */
-  onManualTaskWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskWaitingCallback): Promise<Subscription>;
+  onManualTaskWaiting(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnManualTaskWaitingCallback,
+    subscribeOnce?: boolean,
+  ): Promise<Subscription>;
 
   /**
    * Executes a callback when a ManualTask is finished.
    *
    * @async
-   * @param   identity The requesting users identity.
-   * @param   callback The callback that will be executed when a ManualTask is
-   *                   finished.
-   *                   The message passed to the callback contains further
-   *                   information about the ManualTask.
-   * @returns          The Subscription created by the EventAggregator.
+   * @param   identity      The requesting users identity.
+   * @param   callback      The callback that will be executed when a ManualTask
+   *                        is finished.
+   *                        The message passed to the callback contains further
+   *                        information about the ManualTask.
+   * @param   subscribeOnce Optional: If set to true, the Subscription will be
+   *                        automatically disposed, after the notification was
+   *                        received once.
+   * @returns               The Subscription created by the EventAggregator.
    */
-  onManualTaskFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskFinishedCallback): Promise<Subscription>;
+  onManualTaskFinished(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnManualTaskFinishedCallback,
+    subscribeOnce?: boolean,
+  ): Promise<Subscription>;
 
   /**
    * Executes a callback when a ManualTask for the given identity is reached.

--- a/src/apis/imanual_task_management_api.ts
+++ b/src/apis/imanual_task_management_api.ts
@@ -1,3 +1,4 @@
+import {Subscription} from '@essential-projects/event_aggregator_contracts';
 import {IIdentity} from '@essential-projects/iam_contracts';
 
 import {ManualTaskList} from '../data_models/manual_task/index';
@@ -73,30 +74,36 @@ export interface IManualTaskManagementApi {
    *                       correlation were not found,
    *                       or the user is not authorized to see either.
    */
-  finishManualTask(identity: IIdentity,
-                   processInstanceId: string,
-                   correlationId: string,
-                   manualTaskInstanceId: string): Promise<void>;
+  finishManualTask(
+    identity: IIdentity,
+    processInstanceId: string,
+    correlationId: string,
+    manualTaskInstanceId: string,
+  ): Promise<void>;
 
   /**
    * Executes a callback when a ManualTask is reached.
    *
    * @async
-   * @param identity       The requesting users identity.
-   * @param callback       The callback that will be executed when a ManualTask
-   *                       is reached. The message passed to the callback
-   *                       contains further information about the ManualTask.
+   * @param   identity The requesting users identity.
+   * @param   callback The callback that will be executed when a ManualTask is
+   *                   reached.
+   *                   The message passed to the callback contains further
+   *                   information about the ManualTask.
+   * @returns          The Subscription created by the EventAggregator.
    */
-  onManualTaskWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskWaitingCallback): void;
+  onManualTaskWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskWaitingCallback): Promise<Subscription>;
 
   /**
-   * Executes a callback when a manual task is finished.
+   * Executes a callback when a ManualTask is finished.
    *
    * @async
-   * @param identity       The requesting users identity.
-   * @param callback       The callback that will be executed when a manual task
-   *                       is finished. The message passed to the callback
-   *                       contains further information about the manual task.
+   * @param   identity The requesting users identity.
+   * @param   callback The callback that will be executed when a ManualTask is
+   *                   finished.
+   *                   The message passed to the callback contains further
+   *                   information about the ManualTask.
+   * @returns          The Subscription created by the EventAggregator.
    */
-  onManualTaskFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskFinishedCallback): void;
+  onManualTaskFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnManualTaskFinishedCallback): Promise<Subscription>;
 }

--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -3,6 +3,7 @@ import * as eventApi from './ievent_management_api';
 import * as kpiApi from './ikpi_management_api';
 import * as loggingApi from './ilogging_management_api';
 import * as manualTaskApi from './imanual_task_management_api';
+import * as notificationApi from './inotification_management_api';
 import * as processModelApi from './iprocess_model_management_api';
 import * as tokenHistoryApi from './itoken_history_management_api';
 import * as userTaskApi from './iuser_task_management_api';
@@ -14,6 +15,7 @@ export namespace APIs {
   export import IKpiManagementApi = kpiApi.IKpiManagementApi;
   export import ILoggingManagementApi = loggingApi.ILoggingManagementApi;
   export import IManualTaskManagementApi = manualTaskApi.IManualTaskManagementApi;
+  export import INotificationManagementApi = notificationApi.INotificationManagementApi;
   export import IProcessModelManagementApi = processModelApi.IProcessModelManagementApi;
   export import ITokenHistoryManagementApi = tokenHistoryApi.ITokenHistoryManagementApi;
   export import IUserTaskManagementApi = userTaskApi.IUserTaskManagementApi;

--- a/src/apis/inotification_management_api.ts
+++ b/src/apis/inotification_management_api.ts
@@ -1,5 +1,4 @@
 import {Subscription} from '@essential-projects/event_aggregator_contracts';
-import {IIdentity} from '@essential-projects/iam_contracts';
 
 /**
  * The INotificationManagementApi is to manage subscriptions for async notifications.
@@ -13,12 +12,4 @@ export interface INotificationManagementApi {
    * @param subscription The subscription to remove.
    */
   unsubscribe(subscription: Subscription): Promise<void>;
-
-  /**
-   * Removes all notification subscriptions for the given identity.
-   *
-   * @async
-   * @param identity The identity for which to remove all subscriptions.
-   */
-  unsubscribeAllForIdentity(identity: IIdentity): Promise<void>;
 }

--- a/src/apis/inotification_management_api.ts
+++ b/src/apis/inotification_management_api.ts
@@ -1,4 +1,5 @@
 import {Subscription} from '@essential-projects/event_aggregator_contracts';
+import {IIdentity} from '@essential-projects/iam_contracts';
 
 /**
  * The INotificationManagementApi is to manage subscriptions for async notifications.
@@ -9,7 +10,8 @@ export interface INotificationManagementApi {
    * Removes the given notification subscription.
    *
    * @async
+   * @param identity     The requesting users identity.
    * @param subscription The subscription to remove.
    */
-  removeSubscription(subscription: Subscription): Promise<void>;
+  removeSubscription(identity: IIdentity, subscription: Subscription): Promise<void>;
 }

--- a/src/apis/inotification_management_api.ts
+++ b/src/apis/inotification_management_api.ts
@@ -11,5 +11,5 @@ export interface INotificationManagementApi {
    * @async
    * @param subscription The subscription to remove.
    */
-  unsubscribe(subscription: Subscription): Promise<void>;
+  removeSubscription(subscription: Subscription): Promise<void>;
 }

--- a/src/apis/inotification_management_api.ts
+++ b/src/apis/inotification_management_api.ts
@@ -2,7 +2,7 @@ import {Subscription} from '@essential-projects/event_aggregator_contracts';
 import {IIdentity} from '@essential-projects/iam_contracts';
 
 /**
- * The INotificationManagementApi is to manage subscriptions for async notifications.
+ * The INotificationManagementApi is used to manage subscriptions for async notifications.
  */
 export interface INotificationManagementApi {
 

--- a/src/apis/inotification_management_api.ts
+++ b/src/apis/inotification_management_api.ts
@@ -1,0 +1,24 @@
+import {Subscription} from '@essential-projects/event_aggregator_contracts';
+import {IIdentity} from '@essential-projects/iam_contracts';
+
+/**
+ * The INotificationManagementApi is to manage subscriptions for async notifications.
+ */
+export interface INotificationManagementApi {
+
+  /**
+   * Removes the given notification subscription.
+   *
+   * @async
+   * @param subscription The subscription to remove.
+   */
+  unsubscribe(subscription: Subscription): Promise<void>;
+
+  /**
+   * Removes all notification subscriptions for the given identity.
+   *
+   * @async
+   * @param identity The identity for which to remove all subscriptions.
+   */
+  unsubscribeAllForIdentity(identity: IIdentity): Promise<void>;
+}

--- a/src/apis/iprocess_model_management_api.ts
+++ b/src/apis/iprocess_model_management_api.ts
@@ -106,14 +106,21 @@ export interface IProcessModelManagementApi {
    * Executes a callback when a process started.
    *
    * @async
-   * @param   identity The requesting users identity.
-   * @param   callback The callback that will be executed when a new
-   *                   ProcessInstance was started.
-   *                   The message passed to the callback contains further
-   *                   information about the started process.
-   * @returns          The Subscription created by the EventAggregator.
+   * @param   identity      The requesting users identity.
+   * @param   callback      The callback that will be executed when a new
+   *                        ProcessInstance was started.
+   *                        The message passed to the callback contains further
+   *                        information about the started process.
+   * @param   subscribeOnce Optional: If set to true, the Subscription will be
+   *                        automatically disposed, after the notification was
+   *                        received once.
+   * @returns               The Subscription created by the EventAggregator.
    */
-  onProcessStarted(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessStartedCallback): Promise<Subscription>;
+  onProcessStarted(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnProcessStartedCallback,
+    subscribeOnce?: boolean,
+  ): Promise<Subscription>;
 
   /**
    * Executes a callback when a new ProcessInstance for a given ProcessModelId
@@ -127,37 +134,55 @@ export interface IProcessModelManagementApi {
    *                         information about the started ProcessInstance.
    * @param   processModelId The ID of the ProcessModel for which to receive
    *                         notifications.
+   * @param   subscribeOnce  Optional: If set to true, the Subscription will be
+   *                         automatically disposed, after the notification was
+   *                         received once.
    * @returns                The Subscription created by the EventAggregator.
    */
   onProcessWithProcessModelIdStarted(
     identity: IIdentity,
     callback: Messages.CallbackTypes.OnProcessStartedCallback,
     processModelId: string,
+    subscribeOnce?: boolean,
   ): Promise<Subscription>;
 
   /**
    * Executes a callback when a ProcessInstance is terminated.
    *
    * @async
-   * @param   identity The requesting users identity.
-   * @param   callback The callback that will be executed when a
-   *                   ProcessInstance is terminated.
-   *                   The message passed to the callback contains further
-   *                   information about the ProcessInstance terminated.
-   * @returns          The Subscription created by the EventAggregator.
+   * @param   identity      The requesting users identity.
+   * @param   callback      The callback that will be executed when a
+   *                        ProcessInstance is terminated.
+   *                         The message passed to the callback contains further
+   *                         information about the ProcessInstance terminated.
+   * @param   subscribeOnce Optional: If set to true, the Subscription will be
+   *                        automatically disposed, after the notification was
+   *                        received once.
+   * @returns               The Subscription created by the EventAggregator.
    */
-  onProcessTerminated(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessTerminatedCallback): Promise<Subscription>;
+  onProcessTerminated(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnProcessTerminatedCallback,
+    subscribeOnce?: boolean,
+  ): Promise<Subscription>;
 
   /**
    * Executes a callback when a ProcessInstance ends.
    *
    * @async
-   * @param identity The requesting users identity.
-   * @param callback The callback that will be executed when a
-   *                 ProcessInstance is finished.
-   *                 The message passed to the callback contains further
-   *                 information about the finished ProcessInstance.
-   * @returns        The Subscription created by the EventAggregator.
+   * @param identity        The requesting users identity.
+   * @param callback        The callback that will be executed when a
+   *                        ProcessInstance is finished.
+   *                        The message passed to the callback contains further
+   *                        information about the finished ProcessInstance.
+   * @param   subscribeOnce Optional: If set to true, the Subscription will be
+   *                        automatically disposed, after the notification was
+   *                        received once.
+   * @returns               The Subscription created by the EventAggregator.
    */
-  onProcessEnded(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessEndedCallback): Promise<Subscription>;
+  onProcessEnded(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnProcessEndedCallback,
+    subscribeOnce?: boolean,
+  ): Promise<Subscription>;
 }

--- a/src/apis/iprocess_model_management_api.ts
+++ b/src/apis/iprocess_model_management_api.ts
@@ -1,3 +1,4 @@
+import {Subscription} from '@essential-projects/event_aggregator_contracts';
 import {IIdentity} from '@essential-projects/iam_contracts';
 
 import {
@@ -105,46 +106,58 @@ export interface IProcessModelManagementApi {
    * Executes a callback when a process started.
    *
    * @async
-   * @param identity       The requesting users identity.
-   * @param callback       The callback that will be executed when a new ProcessInstance
-   *                       was started. The message passed to the callback
-   *                       contains further information about the started process.
+   * @param   identity The requesting users identity.
+   * @param   callback The callback that will be executed when a new
+   *                   ProcessInstance was started.
+   *                   The message passed to the callback contains further
+   *                   information about the started process.
+   * @returns          The Subscription created by the EventAggregator.
    */
-  onProcessStarted(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessStartedCallback): void;
+  onProcessStarted(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessStartedCallback): Promise<Subscription>;
 
   /**
-   * Executes a callback when a process with a given ProcessModelId was started.
+   * Executes a callback when a new ProcessInstance for a given ProcessModelId
+   * was started.
    *
    * @async
-   * @param identity       The requesting users identity.
-   * @param callback       The callback that will be executed when a new ProcessInstance
-   *                       was started. The message passed to the callback
-   *                       contains further information about the started process.
-   * @param processModelId Id of the ProcessModel for which created instance a
-  *                        notification should be send.
+   * @param   identity       The requesting users identity.
+   * @param   callback       The callback that will be executed when a new
+   *                         ProcessInstance was started.
+   *                         The message passed to the callback contains further
+   *                         information about the started ProcessInstance.
+   * @param   processModelId The ID of the ProcessModel for which to receive
+   *                         notifications.
+   * @returns                The Subscription created by the EventAggregator.
    */
-  onProcessWithProcessModelIdStarted(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessStartedCallback, processModelId: string): void;
+  onProcessWithProcessModelIdStarted(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnProcessStartedCallback,
+    processModelId: string,
+  ): Promise<Subscription>;
 
   /**
-   * Executes a callback when a process is terminated.
+   * Executes a callback when a ProcessInstance is terminated.
    *
    * @async
-   * @param identity       The requesting users identity.
-   * @param callback       The callback that will be executed when a
-   *                       ProcessInstance was terminated. The message passed to
-   *                       the callback contains further information about the
-   *                       process which was terminated.
+   * @param   identity The requesting users identity.
+   * @param   callback The callback that will be executed when a
+   *                   ProcessInstance is terminated.
+   *                   The message passed to the callback contains further
+   *                   information about the ProcessInstance terminated.
+   * @returns          The Subscription created by the EventAggregator.
    */
-  onProcessTerminated(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessTerminatedCallback): void;
+  onProcessTerminated(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessTerminatedCallback): Promise<Subscription>;
 
   /**
-   * Executes a callback when a process ends.
+   * Executes a callback when a ProcessInstance ends.
    *
    * @async
-   * @param identity       The requesting users identity.
-   * @param callback       The callback that will be executed when a
-   *                       ProcessInstance ended. The message passed to the
-   *                       callback contains further information about the ended process.
+   * @param identity The requesting users identity.
+   * @param callback The callback that will be executed when a
+   *                 ProcessInstance is finished.
+   *                 The message passed to the callback contains further
+   *                 information about the finished ProcessInstance.
+   * @returns        The Subscription created by the EventAggregator.
    */
-  onProcessEnded(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessEndedCallback): void;
+  onProcessEnded(identity: IIdentity, callback: Messages.CallbackTypes.OnProcessEndedCallback): Promise<Subscription>;
 }

--- a/src/apis/iuser_task_management_api.ts
+++ b/src/apis/iuser_task_management_api.ts
@@ -1,3 +1,4 @@
+import {Subscription} from '@essential-projects/event_aggregator_contracts';
 import {IIdentity} from '@essential-projects/iam_contracts';
 
 import {UserTaskList, UserTaskResult} from '../data_models/user_task/index';
@@ -72,31 +73,37 @@ export interface IUserTaskManagementApi {
    *                           correlation were not found,
    *                           or the user is not authorized to see either.
    */
-  finishUserTask(identity: IIdentity,
-                 processInstanceId: string,
-                 correlationId: string,
-                 userTaskInstanceId: string,
-                 userTaskResult: UserTaskResult): Promise<void>;
+  finishUserTask(
+    identity: IIdentity,
+    processInstanceId: string,
+    correlationId: string,
+    userTaskInstanceId: string,
+    userTaskResult: UserTaskResult,
+  ): Promise<void>;
 
   /**
    * Executes a callback when a UserTask is reached.
    *
    * @async
-   * @param identity       The requesting users identity.
-   * @param callback       The callback that will be executed when a UserTask
-   *                       is reached. The message passed to the callback
-   *                       contains further information about the UserTask.
+   * @param   identity The requesting users identity.
+   * @param   callback The callback that will be executed when a UserTask is
+   *                   reached.
+   *                   The message passed to the callback contains further
+   *                   information about the UserTask.
+   * @returns          The Subscription created by the EventAggregator.
    */
-  onUserTaskWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskWaitingCallback): void;
+  onUserTaskWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskWaitingCallback): Promise<Subscription>;
 
   /**
    * Executes a callback when a UserTask is finished.
    *
    * @async
-   * @param identity       The requesting users identity.
-   * @param callback       The callback that will be executed when a UserTask
-   *                       is finished. The message passed to the callback
-   *                       contains further information about the UserTask.
+   * @param   identity The requesting users identity.
+   * @param   callback The callback that will be executed when a UserTask is
+   *                   finished.
+   *                   The message passed to the callback contains further
+   *                   information about the UserTask.
+   * @returns          The Subscription created by the EventAggregator.
    */
-  onUserTaskFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskFinishedCallback): void;
+  onUserTaskFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskFinishedCallback): Promise<Subscription>;
 }

--- a/src/apis/iuser_task_management_api.ts
+++ b/src/apis/iuser_task_management_api.ts
@@ -85,27 +85,41 @@ export interface IUserTaskManagementApi {
    * Executes a callback when a UserTask is reached.
    *
    * @async
-   * @param   identity The requesting users identity.
-   * @param   callback The callback that will be executed when a UserTask is
-   *                   reached.
-   *                   The message passed to the callback contains further
-   *                   information about the UserTask.
-   * @returns          The Subscription created by the EventAggregator.
+   * @param   identity      The requesting users identity.
+   * @param   callback      The callback that will be executed when a UserTask
+   *                        is reached.
+   *                        The message passed to the callback contains further
+   *                        information about the UserTask.
+   * @param   subscribeOnce Optional: If set to true, the Subscription will be
+   *                        automatically disposed, after the notification was
+   *                        received once.
+   * @returns               The Subscription created by the EventAggregator.
    */
-  onUserTaskWaiting(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskWaitingCallback): Promise<Subscription>;
+  onUserTaskWaiting(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnUserTaskWaitingCallback,
+    subscribeOnce?: boolean,
+  ): Promise<Subscription>;
 
   /**
    * Executes a callback when a UserTask is finished.
    *
    * @async
-   * @param   identity The requesting users identity.
-   * @param   callback The callback that will be executed when a UserTask is
-   *                   finished.
-   *                   The message passed to the callback contains further
-   *                   information about the UserTask.
-   * @returns          The Subscription created by the EventAggregator.
+   * @param   identity      The requesting users identity.
+   * @param   callback      The callback that will be executed when a UserTask
+   *                        is finished.
+   *                        The message passed to the callback contains further
+   *                        information about the UserTask.
+   * @param   subscribeOnce Optional: If set to true, the Subscription will be
+   *                        automatically disposed, after the notification was
+   *                        received once.
+   * @returns               The Subscription created by the EventAggregator.
    */
-  onUserTaskFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskFinishedCallback): Promise<Subscription>;
+  onUserTaskFinished(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnUserTaskFinishedCallback,
+    subscribeOnce?: boolean,
+  ): Promise<Subscription>;
 
   /**
    * Executes a callback when a UserTask for the given identity is reached.

--- a/src/apis/iuser_task_management_api.ts
+++ b/src/apis/iuser_task_management_api.ts
@@ -106,4 +106,44 @@ export interface IUserTaskManagementApi {
    * @returns          The Subscription created by the EventAggregator.
    */
   onUserTaskFinished(identity: IIdentity, callback: Messages.CallbackTypes.OnUserTaskFinishedCallback): Promise<Subscription>;
+
+  /**
+   * Executes a callback when a UserTask for the given identity is reached.
+   *
+   * @async
+   * @param identity        The requesting users identity.
+   * @param callback        The callback that will be executed when a UserTask
+   *                        is reached.
+   *                        The message passed to the callback contains further
+   *                        information about the UserTask.
+   * @param   subscribeOnce Optional: If set to true, the Subscription will be
+   *                        automatically disposed, after the notification was
+   *                        received once.
+   * @returns               The Subscription created by the EventAggregator.
+   */
+  onUserTaskForIdentityWaiting(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnUserTaskWaitingCallback,
+    subscribeOnce?: boolean,
+  ): Promise<Subscription>;
+
+  /**
+   * Executes a callback when a UserTask for the given identity is finished.
+   *
+   * @async
+   * @param   identity      The requesting users identity.
+   * @param   callback      The callback that will be executed when a UserTask
+   *                        is finished.
+   *                        The message passed to the callback contains further
+   *                        information about the UserTask.
+   * @param   subscribeOnce Optional: If set to true, the Subscription will be
+   *                        automatically disposed, after the notification was
+   *                        received once.
+   * @returns               The Subscription created by the EventAggregator.
+   */
+  onUserTaskForIdentityFinished(
+    identity: IIdentity,
+    callback: Messages.CallbackTypes.OnUserTaskFinishedCallback,
+    subscribeOnce?: boolean,
+  ): Promise<Subscription>;
 }

--- a/src/imanagement_api.ts
+++ b/src/imanagement_api.ts
@@ -11,6 +11,7 @@ export interface IManagementApi
           APIs.IKpiManagementApi,
           APIs.ILoggingManagementApi,
           APIs.IManualTaskManagementApi,
+          APIs.INotificationManagementApi,
           APIs.IProcessModelManagementApi,
           APIs.ITokenHistoryManagementApi,
           APIs.IUserTaskManagementApi {}

--- a/src/imanagement_api_accessor.ts
+++ b/src/imanagement_api_accessor.ts
@@ -7,4 +7,5 @@ import {IManagementApi} from './imanagement_api';
  * perform the same type of requests as the Service,
  * regardless of which type of ProcessEngine is used.
  */
+// tslint:disable-next-line:no-empty-interface
 export interface IManagementApiAccessor extends IManagementApi {}

--- a/src/imanagement_socket_io_accessor.ts
+++ b/src/imanagement_socket_io_accessor.ts
@@ -1,0 +1,22 @@
+import {IIdentity} from '@essential-projects/iam_contracts';
+
+/**
+ * Provides functions for managing Socket.IO clients.
+ */
+export interface IManagementSocketIoAccessor {
+
+  /**
+   * Uses the given Identity to connect this client to the Socket.IO server.
+   *
+   *
+   * @param identity The identity with which to create the connection.
+   */
+  initializeSocket(identity: IIdentity): void;
+
+  /**
+   * Uses the given Identity to disconnect this client from the Socket.IO server.
+   *
+   * @param identity The identity with which to create the connection.
+   */
+  disconnectSocket(identity: IIdentity): void;
+}

--- a/src/imanagement_socket_io_accessor.ts
+++ b/src/imanagement_socket_io_accessor.ts
@@ -8,7 +8,6 @@ export interface IManagementSocketIoAccessor {
   /**
    * Uses the given Identity to connect this client to the Socket.IO server.
    *
-   *
    * @param identity The identity with which to create the connection.
    */
   initializeSocket(identity: IIdentity): void;

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,8 @@ export * from './apis/index';
 export * from './data_models/index';
 export * from './messages/index';
 
-export * from './imanagement_api';
 export * from './imanagement_api_accessor';
+export * from './imanagement_api';
+export * from './imanagement_socket_io_accessor';
 export * from './rest_settings';
 export * from './socket_settings';

--- a/src/socket_settings.ts
+++ b/src/socket_settings.ts
@@ -1,13 +1,18 @@
 // tslint:disable:typedef
 const pathParams = {
   processModelId: 'process_model_id',
+  userId: 'user_id',
 };
 
 const paths = {
   userTaskWaiting: `user_task_waiting`,
+  userTaskForIdentityWaiting: `user_task_waiting/user_id/${pathParams.userId}`,
   userTaskFinished: `user_task_finished`,
+  userTaskForIdentityFinished: `user_task_finished/user_id/${pathParams.userId}`,
   manualTaskWaiting: `manual_task_waiting`,
+  manualTaskForIdentityWaiting: `manual_task_waiting/user_id/${pathParams.userId}`,
   manualTaskFinished: `manual_task_finished`,
+  manualTaskForIdentityFinished: `manual_task_finished/user_id/${pathParams.userId}`,
   processStarted: `process_started`,
   processEnded: `process_ended`,
   processTerminated: `process_terminated`,


### PR DESCRIPTION
**Changes:**

1. Add interface for Socket.IO accessors. Can be used in conjunction with the client's `ExternalAccessor` to make its Socket.IO handling functions accessible to outside components.
2. Make all functions for creating notification subscriptions return the Subscription they created. 
3. Implement the `removeSubscription` UseCase for the ManagementApi and ConsumerApi, which allows a user to unsubscribe from a notification.
4. Implement `subscribeOnce` flag for all notification Subscriptions. This works pretty much like the `subscribeOnce` UseCase for the EventAggregator.
5. Add identity-based subscriptions for ManualTasks and UserTasks (these were previously implemented in the ConsumerAPI, but were not yet copied over to the ManagementAPI).


**Issues:**

Part of https://github.com/process-engine/process_engine_runtime/issues/#135
Part of https://github.com/process-engine/process_engine_runtime/issues/#157
Part of https://github.com/process-engine/process_engine_runtime/issues/#206

PR: #39

## How can others test the changes?

Implement the updated contracts.
Your subscription functions will now have to return the subscription they created.
Also, you will be able to provide an optional `subscribeOnce` parameter.

## PR-Checklist

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.).
- [x] I've rebased the `develop` branch with my branch before finishing this PR.
- [x] I've **summarized all changes** in a list above.
- [x] I've mentioned all **PRs, which relate to this one**.
- [x] I've prefixed my Pull Request title is according to [gitmoji guide](https://gitmoji.carloscuesta.me/).