### PR TITLE
✨Add getActiveCronjobs UseCase

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/management_api_contracts",
-  "version": "10.0.0",
+  "version": "11.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -14,9 +14,9 @@
       }
     },
     "@babel/highlight": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
-      "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.5.0.tgz",
+      "integrity": "sha512-7dV4eu9gBxoM0dAnj/BCFDW9LFU0zvTrkq0ugM7pnHEgguOEeOz1so2ZghEdzviYzQEED0r4EAgpsBChKy1TRQ==",
       "dev": true,
       "requires": {
         "chalk": "^2.0.0",
@@ -47,9 +47,9 @@
       "integrity": "sha512-/cRthXepb56xb5rjRbeC+Xy+Uu/scExtoe5+f5ckfUKFimjycKtYgiq8wJKJp7QfwzBa1CWe6DTKoJrDX0eEuQ=="
     },
     "@essential-projects/iam_contracts": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@essential-projects/iam_contracts/-/iam_contracts-3.5.0.tgz",
-      "integrity": "sha512-FpYD5RPuTZnttR/Pr/uJ/GElmWMODd8t8KhcE6duk2QHjqPSwMkitAAtr7/D/vzBx4E7kFXW+p6gLvJ5lBO/kQ=="
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@essential-projects/iam_contracts/-/iam_contracts-3.6.0.tgz",
+      "integrity": "sha512-BO8rvdz5TAivDqT+I0At55eLe5XORO98rXGIiXl5+p9cXoyh2VMlSJChgAYYZs1DYKBmSTyZCb/Ptk82Hh9S2Q=="
     },
     "@types/body-parser": {
       "version": "1.17.0",
@@ -99,9 +99,9 @@
       "integrity": "sha512-FwI9gX75FgVBJ7ywgnq/P7tw+/o1GUbtP0KzbtusLigAOgIgNISRK0ZPl4qertvXSIE8YbsVJueQ90cDt9YYyw=="
     },
     "@types/node": {
-      "version": "10.14.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.10.tgz",
-      "integrity": "sha512-V8wj+w2YMNvGuhgl/MA5fmTxgjmVHVoasfIaxMMZJV6Y8Kk+Ydpi1z2whoShDCJ2BuNVoqH/h1hrygnBxkrw/Q=="
+      "version": "10.14.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.12.tgz",
+      "integrity": "sha512-QcAKpaO6nhHLlxWBvpc4WeLrTvPqlHOvaj0s5GriKkA1zq+bsFBPpfYCvQhLqLgYlIko8A9YrPdaMHCo5mBcpg=="
     },
     "@types/range-parser": {
       "version": "1.2.3",
@@ -184,9 +184,9 @@
       }
     },
     "acorn": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
-      "integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.2.0.tgz",
+      "integrity": "sha512-8oe72N3WPMjA+2zVG71Ia0nXZ8DpQH+QyyHO+p06jT8eg8FGG3FbcUIi8KziHlAfheJQZeoqbvq1mQSQHXKYLw==",
       "dev": true
     },
     "acorn-jsx": {
@@ -196,9 +196,9 @@
       "dev": true
     },
     "ajv": {
-      "version": "6.10.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
-      "integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.1.tgz",
+      "integrity": "sha512-w1YQaVGNC6t2UCPjEawK/vo/dG8OOrVtUmhBT1uJJYxbl5kU2Tj3v6LGqBcsysN1yhuCStJCCA3GqdvKY8sqXQ==",
       "dev": true,
       "requires": {
         "fast-deep-equal": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/management_api_contracts",
-  "version": "10.0.0",
+  "version": "11.0.0",
   "description": "interfaces for the process-engine.io Management APIs",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",

--- a/src/apis/icronjob_management_api.ts
+++ b/src/apis/icronjob_management_api.ts
@@ -1,0 +1,22 @@
+import {IIdentity} from '@essential-projects/iam_contracts';
+
+import {CronjobConfiguration} from '../data_models/cronjob/index';
+
+/**
+ * The ICronjobManagementApi is used to query cronjobs from the ProcessEngine.
+ */
+export interface ICronjobManagementApi {
+
+  /**
+   * Retrieves a list of all active cronjobs that the given identity is allowed
+   * to see.
+   *
+   * @async
+   * @param identity             The requesting users identity.
+   * @returns                    A list of cronjobs.
+   *                             Will be empty, if none are available.
+   * @throws {UnauthorizedError} If the given identity does not contain a
+   *                             valid auth token.
+   */
+  getAllActiveCronjobs(identity: IIdentity): Promise<Array<CronjobConfiguration>>;
+}

--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import * as correlationApi from './icorrelation_management_api';
+import * as cronjobApi from './icronjob_management_api';
 import * as emptyActivityApi from './iempty_activity_management_api';
 import * as eventApi from './ievent_management_api';
 import * as flowNodeInstanceApi from './iflow_node_instance_management_api';
@@ -13,6 +14,7 @@ import * as userTaskApi from './iuser_task_management_api';
 
 export namespace APIs {
   export import ICorrelationManagementApi = correlationApi.ICorrelationManagementApi;
+  export import ICronjobManagementApi = cronjobApi.ICronjobManagementApi;
   export import IEmptyActivityManagementApi = emptyActivityApi.IEmptyActivityManagementApi;
   export import IEventManagementApi = eventApi.IEventManagementApi;
   export import IFlowNodeInstanceManagementApi = flowNodeInstanceApi.IFlowNodeInstanceManagementApi;

--- a/src/data_models/cronjob/cronjob.ts
+++ b/src/data_models/cronjob/cronjob.ts
@@ -1,0 +1,17 @@
+/**
+ * Describes a cronjob.
+ */
+export type CronjobConfiguration = {
+  /**
+   * The ID of the ProcessModel that contains the cronjob.
+   */
+  processModelId: string;
+  /**
+   * The ID of the StartEvent that contains the cronjob.
+   */
+  startEventId: string;
+  /**
+   * The crontab that describs the cronjob.
+   */
+  crontab: string;
+}

--- a/src/data_models/cronjob/cronjob.ts
+++ b/src/data_models/cronjob/cronjob.ts
@@ -14,4 +14,8 @@ export type CronjobConfiguration = {
    * The crontab that describs the cronjob.
    */
   crontab: string;
+  /**
+   * The next time the cronjob will be triggered.
+   */
+  nextExecution: Date;
 }

--- a/src/data_models/cronjob/index.ts
+++ b/src/data_models/cronjob/index.ts
@@ -1,0 +1,1 @@
+export * from './cronjob';

--- a/src/data_models/index.ts
+++ b/src/data_models/index.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import * as correlations from './correlation/index';
+import * as cronjobs from './cronjob/index';
 import * as emptyActivities from './empty_activity/index';
 import * as events from './event/index';
 import * as flowNodeInstances from './flow_node_instance/index';
@@ -12,6 +13,7 @@ import * as userTasks from './user_task/index';
 
 export namespace DataModels {
   export import Correlations = correlations;
+  export import Cronjobs = cronjobs;
   export import EmptyActivities = emptyActivities;
   export import Events = events;
   export import FlowNodeInstances = flowNodeInstances;

--- a/src/imanagement_api.ts
+++ b/src/imanagement_api.ts
@@ -7,6 +7,7 @@ import {APIs} from './apis/index';
  */
 export interface IManagementApi
   extends APIs.ICorrelationManagementApi,
+  APIs.ICronjobManagementApi,
   APIs.IEmptyActivityManagementApi,
   APIs.IEventManagementApi,
   APIs.IFlowNodeInstanceManagementApi,

--- a/src/rest_settings.ts
+++ b/src/rest_settings.ts
@@ -25,6 +25,8 @@ const paths = {
   getCorrelationsByProcessModelId: `/correlations/process_model/${params.processModelId}`,
   getCorrelationByProcessInstanceId: `/correlations/process_instance/${params.processInstanceId}`,
   getCorrelationById: `/correlations/${params.correlationId}`,
+  // Cronjobs
+  getActiveCronjobs: '/cronjobs/active',
   // Process Models
   processModels: '/process_models',
   processModelById: `/process_models/${params.processModelId}`,


### PR DESCRIPTION
## Changes

1.Add `ICronjobManagementApi` interface with `getAllActiveCronjobs` UseCase
2. Add public types for Cronjobs
3. Add REST settings for retrieving active cronjobs

## Issues

Part of https://github.com/process-engine/process_engine_runtime/issues/363

PR: #54