### PR TITLE
✨ Add Queries for retrieving ProcessInstances

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/management_api_contracts",
-  "version": "13.0.0",
+  "version": "14.0.0",
   "description": "interfaces for the process-engine.io Management APIs",
   "main": "dist/commonjs/index.js",
   "typings": "dist/index.d.ts",

--- a/src/apis/icorrelation_management_api.ts
+++ b/src/apis/icorrelation_management_api.ts
@@ -5,6 +5,7 @@ import {
   CorrelationList,
   CorrelationState,
   ProcessInstance,
+  ProcessInstanceList,
 } from '../data_models/correlation/index';
 
 /**
@@ -102,7 +103,7 @@ export interface ICorrelationManagementApi {
    * @param   limit          Optional: The max. number of entries to return.
    * @returns                A list with matching ProcessInstances; or an empty Array, if non were found.
    */
-  getProcessInstancesForCorrelation(identity: IIdentity, correlationId: string, offset?: number, limit?: number): Promise<Array<ProcessInstance>>;
+  getProcessInstancesForCorrelation(identity: IIdentity, correlationId: string, offset?: number, limit?: number): Promise<ProcessInstanceList>;
 
   /**
    * Gets a list of all ProcessInstances for the given ProcessModel.
@@ -114,7 +115,7 @@ export interface ICorrelationManagementApi {
    * @param   limit           Optional: The max. number of entries to return.
    * @returns                 A list with matching ProcessInstances; or an empty Array, if non were found.
    */
-  getProcessInstancesForProcessModel(identity: IIdentity, processModelId: string, offset?: number, limit?: number): Promise<Array<ProcessInstance>>;
+  getProcessInstancesForProcessModel(identity: IIdentity, processModelId: string, offset?: number, limit?: number): Promise<ProcessInstanceList>;
 
   /**
    * Gets a list of all ProcessInstances that are in a matching state.
@@ -126,5 +127,5 @@ export interface ICorrelationManagementApi {
    * @param   limit    Optional: The max. number of entries to return.
    * @returns          A list with matching ProcessInstances; or an empty Array, if non were found.
    */
-  getProcessInstancesByState(identity: IIdentity, state: CorrelationState, offset?: number, limit?: number): Promise<Array<ProcessInstance>>;
+  getProcessInstancesByState(identity: IIdentity, state: CorrelationState, offset?: number, limit?: number): Promise<ProcessInstanceList>;
 }

--- a/src/apis/icorrelation_management_api.ts
+++ b/src/apis/icorrelation_management_api.ts
@@ -1,6 +1,6 @@
 import {IIdentity} from '@essential-projects/iam_contracts';
 
-import {Correlation, CorrelationList} from '../data_models/correlation/index';
+import {Correlation, CorrelationList, ProcessInstance} from '../data_models/correlation/index';
 
 /**
  * The ICorrelationManagementApi is used to query correlations.
@@ -73,18 +73,17 @@ export interface ICorrelationManagementApi {
   getCorrelationsByProcessModelId(identity: IIdentity, processModelId: string, offset?: number, limit?: number): Promise<CorrelationList>;
 
   /**
-   * Retrieves the Correlation in which the given ProcessInstance was executed.
+   * Retrieves a ProcessInstance by its iD.
    *
    * @async
    * @param   identity           The requesting users identity.
-   * @param   processInstanceId  The ID of the ProcessInstance for which to get the
-   *                             Correlations.
-   * @returns                    The requested Correlation.
+   * @param   processInstanceId  The ID of the ProcessInstance to get.
+   * @returns                    The requested ProcessInstance.
    * @throws {UnauthorizedError} If the given identity does not contain a
    *                             valid auth token.
    * @throws {ForbiddenError}    If the user is not allowed to access the
    *                             ProcessInstance.
    * @throws {NotFoundError}     If the ProcessInstance does not exist.
    */
-  getCorrelationByProcessInstanceId(identity: IIdentity, processInstanceId: string): Promise<Correlation>;
+  getProcessInstanceById(identity: IIdentity, processInstanceId: string): Promise<ProcessInstance>;
 }

--- a/src/apis/icorrelation_management_api.ts
+++ b/src/apis/icorrelation_management_api.ts
@@ -1,6 +1,11 @@
 import {IIdentity} from '@essential-projects/iam_contracts';
 
-import {Correlation, CorrelationList, ProcessInstance} from '../data_models/correlation/index';
+import {
+  Correlation,
+  CorrelationList,
+  CorrelationState,
+  ProcessInstance,
+} from '../data_models/correlation/index';
 
 /**
  * The ICorrelationManagementApi is used to query correlations.
@@ -86,4 +91,40 @@ export interface ICorrelationManagementApi {
    * @throws {NotFoundError}     If the ProcessInstance does not exist.
    */
   getProcessInstanceById(identity: IIdentity, processInstanceId: string): Promise<ProcessInstance>;
+
+  /**
+   * Gets a list of all ProcessInstances that run in the given Correlation.
+   *
+   * @async
+   * @param   identity       The executing users identity.
+   * @param   correlationId  The ID of the correlation for which to get the ProcessInstances.
+   * @param   offset         Optional: The number of records to skip.
+   * @param   limit          Optional: The max. number of entries to return.
+   * @returns                A list with matching ProcessInstances; or an empty Array, if non were found.
+   */
+  getProcessInstancesForCorrelation(identity: IIdentity, correlationId: string, offset?: number, limit?: number): Promise<Array<ProcessInstance>>;
+
+  /**
+   * Gets a list of all ProcessInstances for the given ProcessModel.
+   *
+   * @async
+   * @param   identity        The executing users identity.
+   * @param   processModelId  The ID of the ProcessModel for which to get the ProcessInstances.
+   * @param   offset          Optional: The number of records to skip.
+   * @param   limit           Optional: The max. number of entries to return.
+   * @returns                 A list with matching ProcessInstances; or an empty Array, if non were found.
+   */
+  getProcessInstancesForProcessModel(identity: IIdentity, processModelId: string, offset?: number, limit?: number): Promise<Array<ProcessInstance>>;
+
+  /**
+   * Gets a list of all ProcessInstances that are in a matching state.
+   *
+   * @async
+   * @param   identity The executing users identity.
+   * @param   state    the state by which to query the ProcessInstances.
+   * @param   offset   Optional: The number of records to skip.
+   * @param   limit    Optional: The max. number of entries to return.
+   * @returns          A list with matching ProcessInstances; or an empty Array, if non were found.
+   */
+  getProcessInstancesByState(identity: IIdentity, state: CorrelationState, offset?: number, limit?: number): Promise<Array<ProcessInstance>>;
 }

--- a/src/data_models/correlation/correlation.ts
+++ b/src/data_models/correlation/correlation.ts
@@ -1,4 +1,4 @@
-import {CorrelationProcessInstance} from './correlation_process_instance';
+import {ProcessInstance} from './process_instance';
 import {CorrelationState} from './correlation_state';
 
 /**
@@ -7,7 +7,7 @@ import {CorrelationState} from './correlation_state';
 export class Correlation {
 
   public id: string;
-  public processInstances: Array<CorrelationProcessInstance>;
+  public processInstances: Array<ProcessInstance>;
   public state: CorrelationState;
   public error: Error;
   public createdAt?: Date;

--- a/src/data_models/correlation/index.ts
+++ b/src/data_models/correlation/index.ts
@@ -1,4 +1,5 @@
-export * from './correlation_process_instance';
 export * from './correlation_state';
 export * from './correlation';
 export * from './correlation_list';
+export * from './process_instance';
+export * from './process_instance_list';

--- a/src/data_models/correlation/process_instance.ts
+++ b/src/data_models/correlation/process_instance.ts
@@ -3,16 +3,17 @@ import {IIdentity} from '@essential-projects/iam_contracts';
 import {CorrelationState} from './correlation_state';
 
 /**
- * Describes a ProcessInstance within a Correlation.
+ * Describes a ProcessInstance.
  */
-export class CorrelationProcessInstance {
+export class ProcessInstance {
 
+  public correlationId: string;
   public processDefinitionName: string;
-  public hash: string;
-  public xml: string;
   public processModelId: string;
   public processInstanceId?: string;
   public parentProcessInstanceId?: string;
+  public hash: string;
+  public xml: string;
   public state: CorrelationState;
   public error: Error;
   public identity: IIdentity;

--- a/src/data_models/correlation/process_instance_list.ts
+++ b/src/data_models/correlation/process_instance_list.ts
@@ -1,0 +1,8 @@
+import {ProcessInstance} from './process_instance';
+
+export class ProcessInstanceList {
+
+  public processInstances: Array<ProcessInstance> = [];
+  public totalCount: number;
+
+}

--- a/src/http_controller/icorrelation_http_controller.ts
+++ b/src/http_controller/icorrelation_http_controller.ts
@@ -47,11 +47,38 @@ export interface ICorrelationHttpController {
   getCorrelationsByProcessModelId(request: HttpRequestWithIdentity, response: Response): Promise<void>;
 
   /**
-   * Retrieves the Correlation in which the given ProcessInstance was executed.
+   * Retrieves a ProcessInstance by its ID.
    *
    * @async
    * @param request  The HttpRequest object containing all request infos.
    * @param response The HttpResponse object to use for sending a Http response.
    */
-  getCorrelationByProcessInstanceId(request: HttpRequestWithIdentity, response: Response): Promise<void>;
+  getProcessInstanceById(request: HttpRequestWithIdentity, response: Response): Promise<void>;
+
+  /**
+   * Gets a list of all ProcessInstances that run in the given Correlation.
+   *
+   * @async
+   * @param request  The HttpRequest object containing all request infos.
+   * @param response The HttpResponse object to use for sending a Http response.
+   */
+  getProcessInstancesForCorrelation(request: HttpRequestWithIdentity, response: Response): Promise<void>;
+
+  /**
+   * Gets a list of all ProcessInstances for the given ProcessModel.
+   *
+   * @async
+   * @param request  The HttpRequest object containing all request infos.
+   * @param response The HttpResponse object to use for sending a Http response.
+   */
+  getProcessInstancesForProcessModel(request: HttpRequestWithIdentity, response: Response): Promise<void>;
+
+  /**
+   * Gets a list of all ProcessInstances that are in a matching state.
+   *
+   * @async
+   * @param request  The HttpRequest object containing all request infos.
+   * @param response The HttpResponse object to use for sending a Http response.
+   */
+  getProcessInstancesByState(request: HttpRequestWithIdentity, response: Response): Promise<void>;
 }

--- a/src/rest_settings.ts
+++ b/src/rest_settings.ts
@@ -7,6 +7,7 @@ const params = {
   processDefinitionsName: ':process_definitions_name',
   processModelId: ':process_model_id',
   processInstanceId: ':process_instance_id',
+  processInstanceState: ':processInstanceState',
   startEventId: ':start_event_id',
   userTaskInstanceId: ':user_task_instance_id',
   manualTaskInstanceId: ':manual_task_instance_id',
@@ -21,11 +22,14 @@ const queryParams = {
 
 const paths = {
   // Correlations
-  getActiveCorrelations: '/correlations/active',
   getAllCorrelations: '/correlations/all',
-  getCorrelationsByProcessModelId: `/correlations/process_model/${params.processModelId}`,
-  getCorrelationByProcessInstanceId: `/correlations/process_instance/${params.processInstanceId}`,
+  getActiveCorrelations: '/correlations/active',
   getCorrelationById: `/correlations/${params.correlationId}`,
+  getCorrelationsByProcessModelId: `/correlations/process_model/${params.processModelId}`,
+  getProcessInstanceById: `/process_instances/${params.processInstanceId}`,
+  getProcessInstancesForCorrelation: `/process_instances/by_correlation/${params.correlationId}`,
+  getProcessInstancesForProcessModel: `/process_instances/by_process_model/${params.processModelId}`,
+  getProcessInstancesByState: `/process_instances/by_state/${params.processInstanceState}`,
   // Cronjobs
   getActiveCronjobs: '/cronjobs/active',
   getCronjobExecutionHistoryForProcessModel: '/cronjobs/history/process_model/:process_model_id',

--- a/src/rest_settings.ts
+++ b/src/rest_settings.ts
@@ -7,7 +7,7 @@ const params = {
   processDefinitionsName: ':process_definitions_name',
   processModelId: ':process_model_id',
   processInstanceId: ':process_instance_id',
-  processInstanceState: ':processInstanceState',
+  processInstanceState: ':process_instance_state',
   startEventId: ':start_event_id',
   userTaskInstanceId: ':user_task_instance_id',
   manualTaskInstanceId: ':manual_task_instance_id',


### PR DESCRIPTION
## Changes

1. Rename `CorrelationProcessInstance` to `ProcessInstance`
2. Rename `CorrelationService.getCorrelationByProcessInstanceId` to `.getProcessInstanceById`
3. Add `correlationId` property to `ProcessInstance` type
4. Add `ProcessInstanceList` DataModel
5. Add UseCases for getting ProcessInstances:
    - getProcessInstancesForCorrelation
    - getProcessInstancesForProcessModel
    - getProcessInstancesByState

## Issues

Part of https://github.com/process-engine/process_engine_runtime/issues/404

PR: #63